### PR TITLE
refactor: move interactions with meta into dedicated module

### DIFF
--- a/helixlauncher-core/src/config.rs
+++ b/helixlauncher-core/src/config.rs
@@ -15,6 +15,7 @@ use std::{
 };
 
 pub const CONFIG_NAME: &str = "config.helix.json";
+const META: &str = "https://meta.helixlauncher.dev/";
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
@@ -29,6 +30,9 @@ pub struct Config {
     libraries_dir: PathBuf,
     #[serde(default = "assets_default")]
     assets_dir: PathBuf,
+
+    #[serde(default = "meta_url_default")]
+    meta_url: String,
 }
 
 fn instances_default() -> PathBuf {
@@ -41,6 +45,10 @@ fn libraries_default() -> PathBuf {
 
 fn assets_default() -> PathBuf {
     PathBuf::from("assets")
+}
+
+fn meta_url_default() -> String {
+    String::from(META)
 }
 
 impl Config {
@@ -103,6 +111,7 @@ impl Config {
             instances_dir: PathBuf::from("instances"),
             libraries_dir: PathBuf::from("libraries"),
             assets_dir: PathBuf::from("assets"),
+            meta_url: meta_url_default(),
         }
     }
 
@@ -120,6 +129,10 @@ impl Config {
 
     pub fn get_assets_path(&self) -> PathBuf {
         self.base_path.join(&self.assets_dir)
+    }
+
+    pub fn get_meta_url(&self) -> &str {
+        &self.meta_url
     }
 }
 

--- a/helixlauncher-core/src/launch/asset.rs
+++ b/helixlauncher-core/src/launch/asset.rs
@@ -16,7 +16,7 @@ use serde::Deserialize;
 
 use lazy_static::lazy_static;
 
-use crate::config::Config;
+use crate::{config::Config, meta::MetaClient};
 
 use super::{
     download_file,
@@ -216,9 +216,10 @@ pub async fn merge_components(
     let mut assets = None;
     let mut main_class = None;
     let mut arguments = vec![];
+    let meta_client = MetaClient::new(config);
 
     for component in components {
-        let mut meta = component.into_meta(config).await?;
+        let mut meta = component.into_meta(&meta_client).await?;
         for trait_ in meta.traits {
             traits.insert(trait_);
         }

--- a/helixlauncher-core/src/launch/instance.rs
+++ b/helixlauncher-core/src/launch/instance.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 
 use crate::{
     config::Config,
-    meta::{ComponentMetaRetrievalError, HelixLauncherMeta},
+    meta::{ComponentMetaRetrievalError, MetaClient},
 };
 
 #[derive(Error, Debug)]
@@ -84,7 +84,7 @@ impl Component {
         &self,
         config: &Config,
     ) -> Result<helixlauncher_meta::component::Component, ComponentMetaRetrievalError> {
-        HelixLauncherMeta::new(config)
+        MetaClient::new(config)
             .get_component_meta(&self.id, &self.version)
             .await
     }

--- a/helixlauncher-core/src/launch/instance.rs
+++ b/helixlauncher-core/src/launch/instance.rs
@@ -5,14 +5,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::Result;
-
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::config::Config;
-
-const META: &str = "https://meta.helixlauncher.dev/";
+use crate::{
+    config::Config,
+    meta::{ComponentMetaRetrievalError, HelixLauncherMeta},
+};
 
 #[derive(Error, Debug)]
 pub enum InstanceManagerError {
@@ -84,36 +83,10 @@ impl Component {
     pub async fn into_meta(
         &self,
         config: &Config,
-    ) -> Result<helixlauncher_meta::component::Component> {
-        // TODO: better caching
-        let component_data_result = async {
-            reqwest::get(format!("{META}{}/{}.json", self.id, self.version))
-                .await?
-                .error_for_status()?
-                .bytes()
-                .await
-        }
-        .await;
-
-        let mut path = config.get_base_path().join("meta");
-        path.push(self.id.clone());
-
-        tokio::fs::create_dir_all(&path).await?;
-
-        path.push(format!("{}.json", self.version));
-
-        let component_data = match component_data_result {
-            Err(e) => match tokio::fs::read(path).await {
-                Err(_) => Err(e)?,
-                Ok(r) => r,
-            },
-            Ok(r) => {
-                tokio::fs::write(path, &r).await?;
-                r.into()
-            }
-        };
-
-        Ok(serde_json::from_slice(&component_data)?)
+    ) -> Result<helixlauncher_meta::component::Component, ComponentMetaRetrievalError> {
+        HelixLauncherMeta::new(config)
+            .get_component_meta(&self.id, &self.version)
+            .await
     }
 }
 

--- a/helixlauncher-core/src/launch/instance.rs
+++ b/helixlauncher-core/src/launch/instance.rs
@@ -8,10 +8,7 @@ use std::{
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{
-    config::Config,
-    meta::{ComponentMetaRetrievalError, MetaClient},
-};
+use crate::meta::{ComponentMetaRetrievalError, MetaClient};
 
 #[derive(Error, Debug)]
 pub enum InstanceManagerError {
@@ -80,11 +77,11 @@ pub struct Component {
 }
 
 impl Component {
-    pub async fn into_meta(
+    pub async fn into_meta<'a>(
         &self,
-        config: &Config,
+        meta_client: &MetaClient<'a>,
     ) -> Result<helixlauncher_meta::component::Component, ComponentMetaRetrievalError> {
-        MetaClient::new(config)
+        meta_client
             .get_component_meta(&self.id, &self.version)
             .await
     }

--- a/helixlauncher-core/src/launch/prepared.rs
+++ b/helixlauncher-core/src/launch/prepared.rs
@@ -15,7 +15,6 @@ use crate::{
     auth::account::Account,
     config::Config,
     fsutil::{check_path, copy_file},
-    meta::HelixLauncherMeta,
 };
 
 use super::{
@@ -311,20 +310,6 @@ pub async fn prepare_launch(
             .collect(),
         working_directory: game_dir,
     })
-}
-
-pub async fn version_exists(path: String, version: String, config: &Config) -> bool {
-    let mut found: bool = false;
-    for item in HelixLauncherMeta::new(config)
-        .get_component_index(&path)
-        .await
-        .expect("Error while checking if version exists")
-    {
-        if item.version == version {
-            found = true;
-        }
-    }
-    found
 }
 
 /*pub async fn mc_version_exists(version: String) -> bool {

--- a/helixlauncher-core/src/lib.rs
+++ b/helixlauncher-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod auth;
 pub mod config;
 mod fsutil;
 pub mod launch;
+pub mod meta;
 
 #[no_mangle]
 pub extern "C" fn test(i: std::ffi::c_int) -> std::ffi::c_int {

--- a/helixlauncher-core/src/meta.rs
+++ b/helixlauncher-core/src/meta.rs
@@ -73,7 +73,10 @@ impl<'a> MetaClient<'a> {
     ) -> Result<helixlauncher_meta::index::Index, ComponentMetaRetrievalError> {
         let response = self
             .client
-            .get(format!("{}{component_id}.json", self.config.get_meta_url()))
+            .get(format!(
+                "{}{component_id}/index.json",
+                self.config.get_meta_url()
+            ))
             .send()
             .await?
             .error_for_status();
@@ -94,8 +97,8 @@ impl<'a> MetaClient<'a> {
 
     pub async fn component_version_exists(
         &self,
-        component_id: String,
-        component_version: String,
+        component_id: &str,
+        component_version: &str,
     ) -> Result<bool, ComponentMetaRetrievalError> {
         Ok(self
             .get_component_index(&component_id)
@@ -117,4 +120,215 @@ pub enum ComponentMetaRetrievalError {
     VersionNotFound { id: String, version: String },
     #[error("Component {id} not found")]
     IndexNotFound { id: String },
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::config::Config;
+
+    use super::*;
+
+    const VALID_TEST_SET: [(&str, [&str; 3]); 1] = [
+        // TODO: adjust to meta changes
+        ("net.minecraft", ["1.16.5", "23w18a", "3D Shareware v1.34"]),
+        // ("org.quiltmc.quilt-loader", ["0.20.0-beta.2", "0.18.9", "0.18.1-beta.10"]),
+        // ("net.fabricmc.fabric-loader", ["", "", ""]),
+        // ("net.minecraftforge.forge", ["", "", ""]),
+    ];
+
+    #[tokio::test]
+    async fn get_component_meta() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let config = Config::new_with_data_dir(
+            "dev.helixlauncher.HelixLauncher",
+            "HelixLauncher",
+            dir.path().join("abc"),
+        )?;
+
+        for (component_id, versions) in VALID_TEST_SET {
+            for component_version in versions {
+                MetaClient::new(&config)
+                    .get_component_meta(component_id, component_version)
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_component_meta_same_client() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let config = Config::new_with_data_dir(
+            "dev.helixlauncher.HelixLauncher",
+            "HelixLauncher",
+            dir.path().join("abc"),
+        )?;
+        let client = MetaClient::new(&config);
+        for (component_id, versions) in VALID_TEST_SET {
+            for component_version in versions {
+                client
+                    .get_component_meta(component_id, component_version)
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_component_index() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let config = Config::new_with_data_dir(
+            "dev.helixlauncher.HelixLauncher",
+            "HelixLauncher",
+            dir.path().join("abc"),
+        )?;
+
+        for (component_id, _) in VALID_TEST_SET {
+            assert!(
+                MetaClient::new(&config)
+                    .get_component_index(component_id)
+                    .await?
+                    .len()
+                    > 5
+            );
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_component_index_same_client() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let config = Config::new_with_data_dir(
+            "dev.helixlauncher.HelixLauncher",
+            "HelixLauncher",
+            dir.path().join("abc"),
+        )?;
+        let client = MetaClient::new(&config);
+        for (component_id, _) in VALID_TEST_SET {
+            assert!(client.get_component_index(component_id).await?.len() > 5);
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn component_version_exists() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let config = Config::new_with_data_dir(
+            "dev.helixlauncher.HelixLauncher",
+            "HelixLauncher",
+            dir.path().join("abc"),
+        )?;
+
+        for (component_id, versions) in VALID_TEST_SET {
+            for component_version in versions {
+                assert!(
+                    MetaClient::new(&config)
+                        .component_version_exists(component_id, component_version)
+                        .await?
+                )
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn component_version_exists_same_client() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let config = Config::new_with_data_dir(
+            "dev.helixlauncher.HelixLauncher",
+            "HelixLauncher",
+            dir.path().join("abc"),
+        )?;
+
+        let client = MetaClient::new(&config);
+        for (component_id, versions) in VALID_TEST_SET {
+            for component_version in versions {
+                assert!(
+                    client
+                        .component_version_exists(component_id, component_version)
+                        .await?
+                )
+            }
+        }
+
+        Ok(())
+    }
+
+    const INVALID_TEST_SET: [(&str, [&str; 3]); 2] = [
+        // first should have invalid index, rest only invalid versions
+        ("com.example", ["1.0.0", "1.0.1", "1.0.2"]),
+        ("net.minecraft", ["4.0.0", "aklsnbafoibesgobo", "100+5=3"]),
+    ];
+
+    #[tokio::test]
+    async fn get_component_meta_invalid_version() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let config = Config::new_with_data_dir(
+            "dev.helixlauncher.HelixLauncher",
+            "HelixLauncher",
+            dir.path().join("abc"),
+        )?;
+
+        for (component_id, versions) in INVALID_TEST_SET {
+            for component_version in versions {
+                assert!(matches!(
+                    MetaClient::new(&config)
+                        .get_component_meta(component_id, component_version)
+                        .await,
+                    Err(ComponentMetaRetrievalError::VersionNotFound {
+                        id,
+                        version
+                    }) if id == component_id && version == component_version
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_component_index_invalid_id() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let config = Config::new_with_data_dir(
+            "dev.helixlauncher.HelixLauncher",
+            "HelixLauncher",
+            dir.path().join("abc"),
+        )?;
+
+        assert!(matches!(
+            MetaClient::new(&config)
+                .get_component_index(INVALID_TEST_SET[0].0)
+                .await,
+            Err(
+                ComponentMetaRetrievalError::IndexNotFound{
+                id
+            }) if id == INVALID_TEST_SET[0].0
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_component_meta_invalid_formatting() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let config = Config::new_with_data_dir(
+            "dev.helixlauncher.HelixLauncher",
+            "HelixLauncher",
+            dir.path().join("abc"),
+        )?;
+
+        assert!(matches!(
+            MetaClient::new(&config)
+                .get_component_meta("net.minecraft", "index")
+                .await,
+            Err(ComponentMetaRetrievalError::ParseError(_))
+        ));
+
+        Ok(())
+    }
 }

--- a/helixlauncher-core/src/meta.rs
+++ b/helixlauncher-core/src/meta.rs
@@ -1,0 +1,91 @@
+use std::io;
+
+use reqwest::Client;
+use thiserror::Error;
+
+use crate::config::Config;
+
+pub struct HelixLauncherMeta<'a> {
+    client: Client,
+    config: &'a Config,
+}
+
+impl<'a> HelixLauncherMeta<'a> {
+    pub fn new(config: &'a Config) -> HelixLauncherMeta<'a> {
+        HelixLauncherMeta {
+            client: Client::new(),
+            config,
+        }
+    }
+
+    pub async fn get_component_meta(
+        &self,
+        component_id: &str,
+        component_version: &str,
+    ) -> Result<helixlauncher_meta::component::Component, ComponentMetaRetrievalError> {
+        // TODO: better caching
+        let component_data_result = async {
+            self.client
+                .get(format!(
+                    "{}{}/{}.json",
+                    self.config.get_meta_url(),
+                    component_id,
+                    component_version
+                ))
+                .send()
+                .await?
+                .error_for_status()?
+                .bytes()
+                .await
+        }
+        .await;
+
+        let mut path = self.config.get_base_path().join("meta");
+        path.push(component_id);
+
+        tokio::fs::create_dir_all(&path).await?;
+
+        path.push(format!("{}.json", component_version));
+
+        let component_data = match component_data_result {
+            Err(e) => match tokio::fs::read(path).await {
+                Err(_) => Err(e)?,
+                Ok(r) => r,
+            },
+            Ok(r) => {
+                tokio::fs::write(path, &r).await?;
+                r.into()
+            }
+        };
+
+        Ok(serde_json::from_slice(&component_data)?)
+    }
+
+    pub async fn get_component_index(
+        &self,
+        component_id: &str,
+    ) -> Result<helixlauncher_meta::index::Index, ComponentMetaRetrievalError> {
+        Ok(self
+            .client
+            .get(format!(
+                "{}{}.json",
+                self.config.get_meta_url(),
+                component_id
+            ))
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?)
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ComponentMetaRetrievalError {
+    #[error(transparent)]
+    IoError(#[from] io::Error),
+    #[error(transparent)]
+    ParseError(#[from] serde_json::Error),
+    #[error(transparent)]
+    ReqwestError(#[from] reqwest::Error),
+}


### PR DESCRIPTION
This PR moves all interactions with meta into one file, which allows for easier improvements in the future and reduces code duplication.
It additionally adds a config option to specify the meta base url.
It might be a good idea to either simplify `get_component_meta` (Which matches the old `Component::into_meta`) or add similar file-based storage to `get_component_index` in order to improve consistency.